### PR TITLE
Fixed parameters.ini instructions

### DIFF
--- a/src/parameters.ini
+++ b/src/parameters.ini
@@ -1,10 +1,10 @@
 
 #----- Possible modes of operation -----------------------------------------------------------------------------------------------------------------#
-# training mode (from scratch): set continue_training to True, and use_pretrained_model to False (if training from scratch).                        #
+# training mode (from scratch): set train_model to True, and use_pretrained_model to False (if training from scratch).                        #
 #				 				Must have train and valid sets in the dataset_text_folder, and test and deployment sets are optional.               #
-# training mode (from pretrained model): set continue_training to True, and use_pretrained_model to True (if training from a pretrained model).     #
+# training mode (from pretrained model): set train_model to True, and use_pretrained_model to True (if training from a pretrained model).     #
 #				 						 Must have train and valid sets in the dataset_text_folder, and test and deployment sets are optional.      #
-# prediction mode (using pretrained model): set continue training to False, and use_pretrained_model to True.                                       #
+# prediction mode (using pretrained model): set train_model to False, and use_pretrained_model to True.                                       #
 #											Must have either a test set or a deployment set.                                                        #
 # NOTE: Whenever use_pretrained_model is set to True, pretrained_model_folder must be set to the folder containing the pretrained model to use, and #
 # 		model.ckpt, dataset.pickle and parameters.ini must exist in the same folder as the checkpoint file.                                         #
@@ -35,8 +35,8 @@ character_embedding_dimension = 25
 character_lstm_hidden_state_dimension = 25
 
 # In order to use random initialization instead, set token_pretrained_embedding_filepath to empty string, as below:
-# token_pretrained_embedding_filepath = 
-token_pretrained_embedding_filepath = ../data/word_vectors/glove.6B.100d.txt 
+# token_pretrained_embedding_filepath =
+token_pretrained_embedding_filepath = ../data/word_vectors/glove.6B.100d.txt
 token_embedding_dimension = 100
 token_lstm_hidden_state_dimension = 100
 
@@ -49,17 +49,17 @@ maximum_number_of_epochs = 100
 # optimizer should be either 'sgd', 'adam', or 'adadelta'
 optimizer = sgd
 learning_rate = 0.005
-# gradients will be clipped above |gradient_clipping_value| and below -|gradient_clipping_value|, if gradient_clipping_value is non-zero 
+# gradients will be clipped above |gradient_clipping_value| and below -|gradient_clipping_value|, if gradient_clipping_value is non-zero
 # (set to 0 to disable gradient clipping)
 gradient_clipping_value = 5.0
 
 # dropout_rate should be between 0 and 1
 dropout_rate = 0.5
 
-# Upper bound on the number of CPU threads NeuroNER will use 
+# Upper bound on the number of CPU threads NeuroNER will use
 number_of_cpu_threads = 8
 
-# Upper bound on the number of GPU NeuroNER will use 
+# Upper bound on the number of GPU NeuroNER will use
 # If number_of_gpus > 0, you need to have installed tensorflow-gpu
 number_of_gpus = 0
 
@@ -73,11 +73,11 @@ tagging_format = bioes
 # - 'spacy' refers to spaCy (https://spacy.io). To install spacy: pip install -U spacy
 # - 'stanford' refers to Stanford CoreNLP (https://stanfordnlp.github.io/CoreNLP/). Stanford CoreNLP is written in Java: to use it one has to start a
 #              Stanford CoreNLP server, which can tokenize sentences given on the fly. Stanford CoreNLP is portable, which means that it can be run
-#              without any installation. 
+#              without any installation.
 #              To download Stanford CoreNLP: https://stanfordnlp.github.io/CoreNLP/download.html
 #              To run Stanford CoreNLP, execute in the terminal: `java -mx4g -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port 9000 -timeout 50000`
 #              By default Stanford CoreNLP is in English. To use it in other languages, see: https://stanfordnlp.github.io/CoreNLP/human-languages.html
-#              Stanford CoreNLP 3.6.0 and higher requires Java 8. We have tested NeuroNER with Stanford CoreNLP 3.6.0. 
+#              Stanford CoreNLP 3.6.0 and higher requires Java 8. We have tested NeuroNER with Stanford CoreNLP 3.6.0.
 tokenizer = spacy
 # spacylanguage should be either 'de' (German), 'en' (English) or 'fr' (French). (https://spacy.io/docs/api/language-models)
 # To install the spaCy language: `python -m spacy.de.download`; or `python -m spacy.en.download`; or `python -m spacy.fr.download`
@@ -86,7 +86,7 @@ spacylanguage = en
 # If remap_unknown_tokens is set to True, map to UNK any token that hasn't been seen in neither the training set nor the pre-trained token embeddings.
 remap_unknown_tokens_to_unk = True
 
-# If load_only_pretrained_token_embeddings is set to True, then token embeddings will only be loaded if it exists in token_pretrained_embedding_filepath 
+# If load_only_pretrained_token_embeddings is set to True, then token embeddings will only be loaded if it exists in token_pretrained_embedding_filepath
 # or in pretrained_model_checkpoint_filepath, even for the training set.
 load_only_pretrained_token_embeddings = False
 


### PR DESCRIPTION
I believe there was a very small mistake in the comments of the `src/parameters.ini` file. They said to set the `continue_training` parameter, but seeing as this doesn't exist, I believe it meant to say to set the `train_model` parameter. 

Heres a tiny pull request to fix that, hopefully I am right in my assessment!