### PR TITLE
Adding the ability to provide command line arguments to prepare_pretrained_model.py

### DIFF
--- a/src/prepare_pretrained_model.py
+++ b/src/prepare_pretrained_model.py
@@ -11,11 +11,14 @@ from entity_lstm import EntityLSTM
 import tensorflow as tf
 import utils_tf
 from tensorflow.python.tools.inspect_checkpoint import print_tensors_in_checkpoint_file
+import argparse
+from argparse import RawTextHelpFormatter
+import sys
 import glob
 
 def trim_dataset_pickle(input_dataset_filepath, output_dataset_filepath=None, delete_token_mappings=False):
     '''
-    Remove the dataset and labels from dataset.pickle. 
+    Remove the dataset and labels from dataset.pickle.
     If delete_token_mappings = True, then also remove token_to_index and index_to_token except for UNK.
     '''
     print("Trimming dataset.pickle..")
@@ -24,13 +27,13 @@ def trim_dataset_pickle(input_dataset_filepath, output_dataset_filepath=None, de
     dataset = pickle.load(open(input_dataset_filepath, 'rb'))
     count = 0
     print("Keys removed:")
-    keys_to_remove = ['character_indices', 'character_indices_padded', 'characters', 'label_indices', 'label_vector_indices', 'labels', 
+    keys_to_remove = ['character_indices', 'character_indices_padded', 'characters', 'label_indices', 'label_vector_indices', 'labels',
                       'token_indices', 'token_lengths', 'tokens', 'infrequent_token_indices', 'tokens_mapped_to_unk']
     for key in keys_to_remove:
         if key in dataset.__dict__:
             del dataset.__dict__[key]
             print('\t' + key)
-            count += 1            
+            count += 1
     if delete_token_mappings:
         dataset.__dict__['token_to_index'] = {dataset.__dict__['UNK']:dataset.__dict__['UNK_TOKEN_INDEX']}
         dataset.__dict__['index_to_token'] = {dataset.__dict__['UNK_TOKEN_INDEX']:dataset.__dict__['UNK']}
@@ -46,28 +49,28 @@ def trim_model_checkpoint(parameters_filepath, dataset_filepath, input_checkpoin
     '''
     parameters, _ = main.load_parameters(parameters_filepath=parameters_filepath)
     dataset = pickle.load(open(dataset_filepath, 'rb'))
-    model = EntityLSTM(dataset, parameters) 
+    model = EntityLSTM(dataset, parameters)
     with tf.Session() as sess:
         model_saver = tf.train.Saver()  # defaults to saving all variables
-        
+
         # Restore the pretrained model
         model_saver.restore(sess, input_checkpoint_filepath) # Works only when the dimensions of tensor variables are matched.
-        
+
         # Get pretrained embeddings
-        token_embedding_weights = sess.run(model.token_embedding_weights) 
-    
+        token_embedding_weights = sess.run(model.token_embedding_weights)
+
         # Restore the sizes of token embedding weights
-        utils_tf.resize_tensor_variable(sess, model.token_embedding_weights, [1, parameters['token_embedding_dimension']]) 
-            
+        utils_tf.resize_tensor_variable(sess, model.token_embedding_weights, [1, parameters['token_embedding_dimension']])
+
         initial_weights = sess.run(model.token_embedding_weights)
         initial_weights[dataset.UNK_TOKEN_INDEX] = token_embedding_weights[dataset.UNK_TOKEN_INDEX]
         sess.run(tf.assign(model.token_embedding_weights, initial_weights, validate_shape=False))
-    
-        token_embedding_weights = sess.run(model.token_embedding_weights) 
+
+        token_embedding_weights = sess.run(model.token_embedding_weights)
         print("token_embedding_weights: {0}".format(token_embedding_weights))
-        
+
         model_saver.save(sess, output_checkpoint_filepath)
-            
+
     dataset.__dict__['vocabulary_size'] = 1
     pickle.dump(dataset, open(dataset_filepath, 'wb'))
     pprint(dataset.__dict__)
@@ -76,16 +79,16 @@ def trim_model_checkpoint(parameters_filepath, dataset_filepath, input_checkpoin
 def prepare_pretrained_model_for_restoring(output_folder_name, epoch_number, model_name, delete_token_mappings=False):
     '''
     Copy the dataset.pickle, parameters.ini, and model checkpoint files after removing the data used for training.
-    
+
     The dataset and labels are deleted from dataset.pickle by default. The only information about the dataset that remain in the pretrained model
     is the list of tokens that appears in the dataset and the corresponding token embeddings learned from the dataset.
-    
+
     If delete_token_mappings is set to True, index_to_token and token_to_index mappings are deleted from dataset.pickle additionally,
     and the corresponding token embeddings are deleted from the model checkpoint files. In this case, the pretrained model would not contain
-    any information about the dataset used for training the model. 
-    
-    If you wish to share a pretrained model with delete_token_mappings = True, it is highly recommended to use some external pre-trained token 
-    embeddings and freeze them while training the model to obtain high performance. This can be done by specifying the token_pretrained_embedding_filepath 
+    any information about the dataset used for training the model.
+
+    If you wish to share a pretrained model with delete_token_mappings = True, it is highly recommended to use some external pre-trained token
+    embeddings and freeze them while training the model to obtain high performance. This can be done by specifying the token_pretrained_embedding_filepath
     and setting freeze_token_embeddings = True in parameters.ini for training.
     '''
     input_model_folder = os.path.join('..', 'output', output_folder_name, 'model')
@@ -96,11 +99,11 @@ def prepare_pretrained_model_for_restoring(output_folder_name, epoch_number, mod
     input_dataset_filepath = os.path.join(input_model_folder, 'dataset.pickle')
     output_dataset_filepath = os.path.join(output_model_folder, 'dataset.pickle')
     trim_dataset_pickle(input_dataset_filepath, output_dataset_filepath, delete_token_mappings=delete_token_mappings)
-    
+
     # copy parameters.ini
     parameters_filepath = os.path.join(input_model_folder, 'parameters.ini')
     shutil.copy(parameters_filepath, output_model_folder)
-    
+
     # (trim and) copy checkpoint files
     epoch_number_string = str(epoch_number).zfill(5)
     if delete_token_mappings:
@@ -111,11 +114,11 @@ def prepare_pretrained_model_for_restoring(output_folder_name, epoch_number, mod
         for filepath in glob.glob(os.path.join(input_model_folder, 'model_{0}.ckpt*'.format(epoch_number_string))):
             shutil.copyfile(filepath, os.path.join(output_model_folder, os.path.basename(filepath).replace('_' + epoch_number_string, '')))
 
- 
+
 def check_contents_of_dataset_and_model_checkpoint(model_folder):
     '''
     Check the contents of dataset.pickle and model_xxx.ckpt.
-    model_folder: folder containing dataset.pickle and model_xxx.ckpt to be checked. 
+    model_folder: folder containing dataset.pickle and model_xxx.ckpt to be checked.
     '''
     dataset_filepath = os.path.join(model_folder, 'dataset.pickle')
     dataset = pickle.load(open(dataset_filepath, 'rb'))
@@ -127,14 +130,39 @@ def check_contents_of_dataset_and_model_checkpoint(model_folder):
         print_tensors_in_checkpoint_file(checkpoint_filepath, tensor_name='token_embedding/token_embedding_weights', all_tensors=True)
         print_tensors_in_checkpoint_file(checkpoint_filepath, tensor_name='token_embedding/token_embedding_weights', all_tensors=False)
 
+def parse_arguments(arguments=None):
+    ''' Parse the NeuroNER arguments
+
+    arguments:
+        arguments the arguments, optionally given as argument
+    '''
+    parser = argparse.ArgumentParser(description='''NeuroNER CLI - Prepare Pretrained Model''', formatter_class=RawTextHelpFormatter)
+
+    parser.add_argument('--output_folder_name', required=False, default='en_2017-05-05_08-58-32-633799', help='Name of the output folder created during training')
+    parser.add_argument('--epoch_number', required=False, type = int, default='30', help='Epoch number of trained model to use')
+    parser.add_argument('--model_name', required=False, default='conll_2003_en', help='Name of the pre-trained model to be created')
+    parser.add_argument('--delete_token_mappings', required=False, action='store_true', default=False, help='Flag to delete token mappings')
+
+    try:
+        arguments = parser.parse_args(args=arguments)
+    except:
+        parser.print_help()
+        sys.exit(0)
+
+    arguments = vars(arguments)
+    return arguments
+
 
 if __name__ == '__main__':
-    output_folder_name = 'en_2017-05-05_08-58-32-633799'
-    epoch_number = 30
-    model_name = 'conll_2003_en'
-    delete_token_mappings = False
+    # parse and store command line arguments
+    arguments = parse_arguments(sys.argv[1:])
+    output_folder_name = arguments['output_folder_name']
+    epoch_number = arguments['epoch_number']
+    model_name = arguments['model_name']
+    delete_token_mappings = arguments['delete_token_mappings']
+
     prepare_pretrained_model_for_restoring(output_folder_name, epoch_number, model_name, delete_token_mappings)
-    
+
 #     model_name = 'mimic_glove_spacy_iobes'
 #     model_folder = os.path.join('..', 'trained_models', model_name)
 #     check_contents_of_dataset_and_model_checkpoint(model_folder)

--- a/src/utils_plots.py
+++ b/src/utils_plots.py
@@ -33,7 +33,7 @@ def show_values(pc, fmt="%.2f", **kw):
     By HYRY
     '''
     pc.update_scalarmappable()
-    ax = pc.get_axes()
+    ax = pc.axes
     for p, color, value in zip(pc.get_paths(), pc.get_facecolors(), pc.get_array()):
         x, y = p.vertices[:-2, :].mean(0)
         if np.all(color[:3] > 0.5):


### PR DESCRIPTION
I added the ability to provide command line arguments during a call to the `prepare_pretrained_model.py` script. As otherwise, users would need to modify code in order to change this (to the best of my understanding). I tried to follow the way arguments are parsed in `main.py` as closely as possible. 

#### Essentially,

I added a `parse_arguments()` function which is called before `prepare_pretrained_model_for_restoring()`. It adds and parses four arguments:
- `--output_folder_name` Name of the output folder from the training step. 
- `--epoch_number` Epoch number to use when creating the pre-trained model.
- `--model_name` Name of the model to be saved.
- `--delete_token_mappings` Flag which indicates if token mappings should be deleted. 

The default value of each are the arguments originally stored in the `prepare_pretrained_model.py` script (wasn't totally sure what to set them to, so I went with that).