### PR TITLE
Check NeuroNER has sess attr before closing

### DIFF
--- a/src/neuroner.py
+++ b/src/neuroner.py
@@ -486,6 +486,7 @@ class NeuroNER(object):
         self.__del__()
     
     def __del__(self):
-        self.sess.close()
+        if hasattr(self, 'sess'):
+            self.sess.close()
     
 


### PR DESCRIPTION
I was gettng the following exception when running main.py:

Exception ignored in: <bound method NeuroNER.__del__ of <neuroner.NeuroNER object at 0x10db79ac8>>
Traceback (most recent call last):
  File "/Users/hannahprovenza/Development/duolingo/NeuroNER-master/src/neuroner.py", line 489, in __del__
    if self.sess:
AttributeError: 'NeuroNER' object has no attribute 'sess'

My change stops it by checking that the sess attribute exists before attempting to close it.