### PR TITLE
Add to pypi as pyneuroner. Closes #133

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ For GPU support, [GPU requirements for Tensorflow](https://www.tensorflow.org/in
 
 ```
 # For CPU support (no GPU support):
-pip3 install neuroner[cpu]
+pip3 install pyneuroner[cpu]
 
 # For GPU support:
-pip3 install neuroner[gpu]
+pip3 install pyneuroner[gpu]
 ```
 
 You will also need to download some support packages.

--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,12 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 #     print(directory)
 
 setup(
-    name='neuroner',
+    name='pyneuroner',
 
     # Versions should comply with PEP440. For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.5.2',
+    version='1.0-dev3',
 
     description='NeuroNER',
     long_description=long_description,


### PR DESCRIPTION
Change the pypi installation name to "pyneuroner".

The package can now be installed with `pip3 install pyneuroner`.