### PR TITLE
fix import in xml_to_brat file

### DIFF
--- a/neuroner/data/i2b2_2014_deid/xml_to_brat.py
+++ b/neuroner/data/i2b2_2014_deid/xml_to_brat.py
@@ -9,8 +9,7 @@ import glob
 import codecs
 import shutil
 
-sys.path.append(os.path.join('..','..','neuroner'))
-from conll_to_brat import output_entities
+from neuroner.conll_to_brat import output_entities
 import utils
 
 


### PR DESCRIPTION
Now that the NeuroNER is pip installed, `output_entities` can be imported from the package itself, instead of a hardcoded path.