### PR TITLE
Add output_scores option and fix issue with _clean_param_dtypes. ref #101 

### DIFF
--- a/neuroner/__main__.py
+++ b/neuroner/__main__.py
@@ -45,6 +45,7 @@ def parse_arguments(arguments=None):
     parser.add_argument('--number_of_gpus', required=False, default=None, help='')
     parser.add_argument('--optimizer', required=False, default=None, help='')
     parser.add_argument('--output_folder', required=False, default=None, help='')
+    parser.add_argument('--output_scores', required=False, default=None, help='')
     parser.add_argument('--patience', required=False, default=None, help='')
     parser.add_argument('--plot_format', required=False, default=None, help='')
     parser.add_argument('--pretrained_model_folder', required=False, default=None, help='')

--- a/neuroner/neuromodel.py
+++ b/neuroner/neuromodel.py
@@ -37,7 +37,7 @@ warnings.filterwarnings('ignore')
 def fetch_model(name):
     """
     Fetch a pre-trained model and copy to a local "trained_models" folder
-     If name is provided, fetch from the package folder. 
+     If name is provided, fetch from the package folder.
 
     Args:
         name (str): Name of a model folder.
@@ -49,11 +49,12 @@ def fetch_model(name):
     # model.ckpt.index
     # model.ckpt.meta
     # parameters.ini
-    _fetch(name,content_type="trained_models") 
+    _fetch(name, content_type="trained_models") 
+
 
 def fetch_data(name):
     """
-    Fetch a dataset. If name is provided, fetch from the package folder. If url 
+    Fetch a dataset. If name is provided, fetch from the package folder. If url
     is provided, fetch from a remote location.
 
     Args:
@@ -61,9 +62,10 @@ def fetch_data(name):
         url (str): URL of a model folder.
     """
     # get content from package and write to local dir
-    _fetch(name,content_type="data")      
+    _fetch(name, content_type="data")
 
-def _fetch(name,content_type=None):
+
+def _fetch(name, content_type=None):
     """
     Load data or models from the package folder.
 
@@ -78,10 +80,10 @@ def _fetch(name,content_type=None):
     resource_path = '/'.join((content_type, name))
 
     # get dirs
-    root_dir = os.path.dirname(pkg_resources.resource_filename(package_name, 
+    root_dir = os.path.dirname(pkg_resources.resource_filename(package_name,
         '__init__.py'))
     src_dir = os.path.join(root_dir, resource_path)
-    dest_dir = os.path.join('.',content_type,name)
+    dest_dir = os.path.join('.', content_type, name)
 
     if pkg_resources.resource_isdir(package_name, resource_path):
 
@@ -96,6 +98,7 @@ def _fetch(name,content_type=None):
     else:
         msg = "{} not found in {} package.".format(name,package_name)
         print(msg)
+
 
 def _get_default_param():
     """
@@ -146,6 +149,7 @@ def _get_default_param():
 
     return param
 
+
 def _get_config_param(param_filepath=None):
     """
     Get the parameters from the config file.
@@ -157,10 +161,12 @@ def _get_config_param(param_filepath=None):
         param_file_txt = configparser.ConfigParser()
         param_file_txt.read(param_filepath, encoding="UTF-8")
         nested_parameters = utils.convert_configparser_to_dictionary(param_file_txt)
-        for k,v in nested_parameters.items():
+
+        for k, v in nested_parameters.items():
             param.update(v)
 
     return param, param_file_txt
+
 
 def _clean_param_dtypes(param):
     """
@@ -171,7 +177,7 @@ def _clean_param_dtypes(param):
     """
 
     # Set the data type
-    for k,v in param.items():
+    for k, v in param.items():
         v = str(v)
         # If the value is a list delimited with a comma, choose one element at random.
         # NOTE: review this behaviour.
@@ -180,28 +186,34 @@ def _clean_param_dtypes(param):
             param[k] = v
 
         # Ensure that each parameter is cast to the correct type
-        if k in ['character_embedding_dimension','character_lstm_hidden_state_dimension',
-            'token_embedding_dimension','token_lstm_hidden_state_dimension','patience',
-            'maximum_number_of_epochs','maximum_training_time','number_of_cpu_threads','number_of_gpus']:
+        if k in ['character_embedding_dimension',
+            'character_lstm_hidden_state_dimension', 'token_embedding_dimension',
+            'token_lstm_hidden_state_dimension', 'patience',
+            'maximum_number_of_epochs', 'maximum_training_time',
+            'number_of_cpu_threads', 'number_of_gpus']:
             param[k] = int(v)
         elif k in ['dropout_rate', 'learning_rate', 'gradient_clipping_value']:
             param[k] = float(v)
-        elif k in ['remap_unknown_tokens_to_unk', 'use_character_lstm', 'use_crf', 
-            'train_model', 'use_pretrained_model', 'debug', 'verbose',
-                 'reload_character_embeddings', 'reload_character_lstm', 'reload_token_embeddings', 
-                 'reload_token_lstm', 'reload_feedforward', 'reload_crf',
-                 'check_for_lowercase', 'check_for_digits_replaced_with_zeros', 
-                 'freeze_token_embeddings', 'load_only_pretrained_token_embeddings']:
+        elif k in ['remap_unknown_tokens_to_unk', 'use_character_lstm',
+            'use_crf', 'train_model', 'use_pretrained_model', 'debug', 'verbose',
+            'reload_character_embeddings', 'reload_character_lstm',
+            'reload_token_embeddings', 'reload_token_lstm',
+            'reload_feedforward', 'reload_crf', 'check_for_lowercase',
+            'check_for_digits_replaced_with_zeros', 'output_scores',
+            'freeze_token_embeddings', 'load_only_pretrained_token_embeddings']:
             param[k] = distutils.util.strtobool(v)
 
     return param
 
+
 def load_parameters(**kwargs):
     '''
-    Load parameters from the ini file if specified, take into account any command
-    line argument, and ensure that each parameter is cast to the correct type.
+    Load parameters from the ini file if specified, take into account any
+    command line argument, and ensure that each parameter is cast to the
+    correct type.
 
-    Command line arguments take precedence over parameters specified in the parameter file.
+    Command line arguments take precedence over parameters specified in the
+    parameter file.
     '''
     param = {}
     param_default = _get_default_param()
@@ -228,6 +240,9 @@ def load_parameters(**kwargs):
         if k not in param:
             param[k] = param_default[k]
 
+    # clean the data types
+    param = _clean_param_dtypes(param)
+
     # if loading a pretrained model, set to pretrain hyperparameters
     if param['use_pretrained_model']:
 
@@ -252,9 +267,6 @@ def load_parameters(**kwargs):
             msg = """Warning: pretraining parameter file not found."""
             print(msg)
 
-    # clean the data types
-    param = _clean_param_dtypes(param)
-
     # # if running tests
     # if param['experiment_name'] == 'test':
     #     param_file_txt = configparser.ConfigParser()
@@ -264,7 +276,7 @@ def load_parameters(**kwargs):
     # update param_file_txt to reflect the overriding
     param_to_section = utils.get_parameter_to_section_of_configparser(param_file_txt)
     for k, v in param.items():
-        try: 
+        try:
             param_file_txt.set(param_to_section[k], k, str(v))
         except:
             pass
@@ -273,6 +285,7 @@ def load_parameters(**kwargs):
         pprint(param)
 
     return param, param_file_txt
+
 
 def get_valid_dataset_filepaths(parameters):
     """
@@ -346,6 +359,7 @@ def get_valid_dataset_filepaths(parameters):
 
     return dataset_filepaths, dataset_brat_folders
 
+
 def check_param_compatibility(parameters, dataset_filepaths):
     """
     Check parameters are compatible.
@@ -380,6 +394,13 @@ def check_param_compatibility(parameters, dataset_filepaths):
     if parameters['gradient_clipping_value'] < 0:
         parameters['gradient_clipping_value'] = abs(parameters['gradient_clipping_value'])
 
+    if parameters['output_scores'] and parameters['use_crf']:
+        warn_msg = """Warning when use_crf is True, scores are decoded
+        using the crf. As a result, the scores cannot be directly interpreted
+        in terms of class prediction.
+        """
+        warnings.warn(warn_msg)
+
 
 class NeuroNER(object):
     """
@@ -407,6 +428,7 @@ class NeuroNER(object):
         number_of_gpus (type): description
         optimizer (type): description
         output_folder (type): description
+        output_scores (bool): description
         patience (type): description
         plot_format (type): description
         reload_character_embeddings (type): description
@@ -435,6 +457,7 @@ class NeuroNER(object):
 
         # Set parameters
         self.parameters, self.conf_parameters = load_parameters(**kwargs)
+
         self.dataset_filepaths, self.dataset_brat_folders = self._get_valid_dataset_filepaths(self.parameters)
         self._check_param_compatibility(self.parameters, self.dataset_filepaths)
 
@@ -445,11 +468,11 @@ class NeuroNER(object):
         # Launch session. Automatically choose a device
         # if the specified one doesn't exist
         session_conf = tf.ConfigProto(
-        intra_op_parallelism_threads=self.parameters['number_of_cpu_threads'],
-        inter_op_parallelism_threads=self.parameters['number_of_cpu_threads'],
-        device_count={'CPU': 1, 'GPU': self.parameters['number_of_gpus']},
-        allow_soft_placement=True, 
-        log_device_placement=False)
+            intra_op_parallelism_threads=self.parameters['number_of_cpu_threads'],
+            inter_op_parallelism_threads=self.parameters['number_of_cpu_threads'],
+            device_count={'CPU': 1, 'GPU': self.parameters['number_of_gpus']},
+            allow_soft_placement=True,
+            log_device_placement=False)
 
         self.sess = tf.Session(config=session_conf)
         with self.sess.as_default():
@@ -459,10 +482,10 @@ class NeuroNER(object):
             self.sess.run(tf.global_variables_initializer())
 
             if self.parameters['use_pretrained_model']:
-                self.transition_params_trained = self.model.restore_from_pretrained_model(self.parameters, 
+                self.transition_params_trained = self.model.restore_from_pretrained_model(self.parameters,
                     self.modeldata, self.sess, token_to_vector=token_to_vector)
             else:
-                self.model.load_pretrained_token_embeddings(self.sess, self.modeldata, 
+                self.model.load_pretrained_token_embeddings(self.sess, self.modeldata,
                     self.parameters, token_to_vector)
                 self.transition_params_trained = np.random.rand(len(self.modeldata.unique_labels)+2,
                     len(self.modeldata.unique_labels)+2)
@@ -483,7 +506,7 @@ class NeuroNER(object):
         stats_graph_folder = os.path.join(parameters['output_folder'], model_name) 
         utils.create_folder_if_not_exists(stats_graph_folder)
         return stats_graph_folder, experiment_timestamp
-    
+
     def _get_valid_dataset_filepaths(self, parameters, dataset_types=['train', 'valid', 'test', 'deploy']):
         """
         Get paths for the datasets.
@@ -502,21 +525,21 @@ class NeuroNER(object):
                 dataset_type)
             dataset_compatible_with_brat_filepath = os.path.join(parameters['dataset_text_folder'], 
                 '{0}_compatible_with_brat.txt'.format(dataset_type))
-    
+
             # Conll file exists
             if os.path.isfile(dataset_filepaths[dataset_type]) \
             and os.path.getsize(dataset_filepaths[dataset_type]) > 0:
                 # Brat text files exist
                 if os.path.exists(dataset_brat_folders[dataset_type]) and \
                 len(glob.glob(os.path.join(dataset_brat_folders[dataset_type], '*.txt'))) > 0:
-    
+
                     # Check compatibility between conll and brat files
                     brat_to_conll.check_brat_annotation_and_text_compatibility(dataset_brat_folders[dataset_type])
                     if os.path.exists(dataset_compatible_with_brat_filepath):
                         dataset_filepaths[dataset_type] = dataset_compatible_with_brat_filepath
                     conll_to_brat.check_compatibility_between_conll_and_brat_text(dataset_filepaths[dataset_type], 
                         dataset_brat_folders[dataset_type])
-    
+
                 # Brat text files do not exist
                 else:
                     # Populate brat text and annotation files based on conll file
@@ -524,7 +547,7 @@ class NeuroNER(object):
                         dataset_compatible_with_brat_filepath, dataset_brat_folders[dataset_type], 
                         dataset_brat_folders[dataset_type])
                     dataset_filepaths[dataset_type] = dataset_compatible_with_brat_filepath
-    
+
             # Conll file does not exist
             else:
                 # Brat text files exist
@@ -540,23 +563,23 @@ class NeuroNER(object):
                         brat_to_conll.brat_to_conll(dataset_brat_folders[dataset_type], 
                             dataset_filepath_for_tokenizer, parameters['tokenizer'], parameters['spacylanguage'])
                     dataset_filepaths[dataset_type] = dataset_filepath_for_tokenizer
-    
+
                 # Brat text files do not exist
                 else:
                     del dataset_filepaths[dataset_type]
                     del dataset_brat_folders[dataset_type]
                     continue
-    
+
             if parameters['tagging_format'] == 'bioes':
                 # Generate conll file with BIOES format
-                bioes_filepath = os.path.join(parameters['dataset_text_folder'], 
+                bioes_filepath = os.path.join(parameters['dataset_text_folder'],
                     '{0}_bioes.txt'.format(utils.get_basename_without_extension(dataset_filepaths[dataset_type])))
-                utils_nlp.convert_conll_from_bio_to_bioes(dataset_filepaths[dataset_type], 
+                utils_nlp.convert_conll_from_bio_to_bioes(dataset_filepaths[dataset_type],
                     bioes_filepath)
                 dataset_filepaths[dataset_type] = bioes_filepath
-    
+
         return dataset_filepaths, dataset_brat_folders
-    
+
     def _check_param_compatibility(self, parameters, dataset_filepaths):
         """
         Check parameters are compatible.
@@ -566,7 +589,7 @@ class NeuroNER(object):
             dataset_filepaths (type): description.
         """
         check_param_compatibility(parameters, dataset_filepaths)
-   
+
     def fit(self):
         """
         Fit the model.
@@ -598,7 +621,7 @@ class NeuroNER(object):
         with open(os.path.join(model_folder, 'parameters.ini'), 'w') as parameters_file:
             conf_parameters.write(parameters_file)
         pickle.dump(modeldata, open(os.path.join(model_folder, 'dataset.pickle'), 'wb'))
-            
+
         tensorboard_log_folder = os.path.join(stats_graph_folder, 'tensorboard_logs')
         utils.create_folder_if_not_exists(tensorboard_log_folder)
         tensorboard_log_folders = {}
@@ -606,7 +629,7 @@ class NeuroNER(object):
             tensorboard_log_folders[dataset_type] = os.path.join(stats_graph_folder, 
                 'tensorboard_logs', dataset_type)
             utils.create_folder_if_not_exists(tensorboard_log_folders[dataset_type])
-                
+
         # Instantiate the writers for TensorBoard
         writers = {}
         for dataset_type in dataset_filepaths.keys():
@@ -614,7 +637,7 @@ class NeuroNER(object):
                 graph=sess.graph)
 
         # embedding_writer has to write in model_folder, otherwise TensorBoard won't be able to view embeddings
-        embedding_writer = tf.summary.FileWriter(model_folder) 
+        embedding_writer = tf.summary.FileWriter(model_folder)
 
         embeddings_projector_config = projector.ProjectorConfig()
         tensorboard_token_embeddings = embeddings_projector_config.embeddings.add()
@@ -646,7 +669,7 @@ class NeuroNER(object):
 
         # Start training + evaluation loop. Each iteration corresponds to 1 epoch.
         # number of epochs with no improvement on the validation test in terms of F1-score
-        bad_counter = 0 
+        bad_counter = 0
         previous_best_valid_f1_score = 0
         epoch_number = -1
         try:
@@ -666,19 +689,19 @@ class NeuroNER(object):
                             sequence_number, model, parameters)
                         step += 1
                         if step % 10 == 0:
-                            print('Training {0:.2f}% done'.format(step/len(sequence_numbers)*100), 
+                            print('Training {0:.2f}% done'.format(step/len(sequence_numbers)*100),
                                 end='\r', flush=True)
 
                 epoch_elapsed_training_time = time.time() - epoch_start_time
-                print('Training completed in {0:.2f} seconds'.format(epoch_elapsed_training_time), 
+                print('Training completed in {0:.2f} seconds'.format(epoch_elapsed_training_time),
                     flush=True)
 
-                y_pred, y_true, output_filepaths = train.predict_labels(sess, model, 
-                    transition_params_trained, parameters, modeldata, epoch_number, 
+                y_pred, y_true, output_filepaths = train.predict_labels(sess, model,
+                    transition_params_trained, parameters, modeldata, epoch_number,
                     stats_graph_folder, dataset_filepaths)
 
                 # Evaluate model: save and plot results
-                evaluate.evaluate_model(results, modeldata, y_pred, y_true, stats_graph_folder, 
+                evaluate.evaluate_model(results, modeldata, y_pred, y_true, stats_graph_folder,
                     epoch_number, epoch_start_time, output_filepaths, parameters)
 
                 if parameters['use_pretrained_model'] and not parameters['train_model']:
@@ -700,7 +723,7 @@ class NeuroNER(object):
                 if  valid_f1_score > previous_best_valid_f1_score:
                     bad_counter = 0
                     previous_best_valid_f1_score = valid_f1_score
-                    conll_to_brat.output_brat(output_filepaths, dataset_brat_folders, 
+                    conll_to_brat.output_brat(output_filepaths, dataset_brat_folders,
                         stats_graph_folder, overwrite=True)
                     self.transition_params_trained = transition_params_trained
                 else:
@@ -712,7 +735,8 @@ class NeuroNER(object):
                     results['execution_details']['early_stop'] = True
                     break
 
-                if epoch_number >= parameters['maximum_number_of_epochs']: break
+                if epoch_number >= parameters['maximum_number_of_epochs']:
+                    break
 
         except KeyboardInterrupt:
             results['execution_details']['keyboard_interrupt'] = True
@@ -734,11 +758,11 @@ class NeuroNER(object):
             text (str): Description.
         """
         self.prediction_count += 1        
-        
+
         if self.prediction_count == 1:
             self.parameters['dataset_text_folder'] = os.path.join('.', 'data', 'temp')
             self.stats_graph_folder, _ = self._create_stats_graph_folder(self.parameters)
-        
+
         # Update the deploy folder, file, and modeldata 
         dataset_type = 'deploy'
 
@@ -768,16 +792,18 @@ class NeuroNER(object):
 
         # Update the dataset for the new deploy set
         self.modeldata.update_dataset(self.dataset_filepaths, [dataset_type])
-        
+
         # Predict labels and output brat
         output_filepaths = {}
-        prediction_output = train.prediction_step(self.sess, self.modeldata, 
-            dataset_type, self.model, self.transition_params_trained, self.stats_graph_folder, 
-            self.prediction_count, self.parameters, self.dataset_filepaths)
+        prediction_output = train.prediction_step(self.sess, self.modeldata,
+            dataset_type, self.model, self.transition_params_trained,
+            self.stats_graph_folder, self.prediction_count, self.parameters,
+            self.dataset_filepaths)
+
         _, _, output_filepaths[dataset_type] = prediction_output
         conll_to_brat.output_brat(output_filepaths, self.dataset_brat_folders, 
             self.stats_graph_folder, overwrite=True)
-        
+
         # Print and output result
         text_filepath = os.path.join(self.stats_graph_folder, 'brat', 'deploy', 
             os.path.basename(dataset_brat_deploy_filepath))
@@ -787,12 +813,12 @@ class NeuroNER(object):
             annotation_filepath, verbose=True)
         assert(text == text2)
         return entities
-    
+
     def get_params(self):
         return self.parameters
-    
+
     def close(self):
         self.__del__()
-    
+
     def __del__(self):
         self.sess.close()

--- a/neuroner/neuromodel.py
+++ b/neuroner/neuromodel.py
@@ -242,6 +242,7 @@ def load_parameters(**kwargs):
 
     # clean the data types
     param = _clean_param_dtypes(param)
+    print(param)
 
     # if loading a pretrained model, set to pretrain hyperparameters
     if param['use_pretrained_model']:
@@ -251,13 +252,14 @@ def load_parameters(**kwargs):
 
         if os.path.isfile(pretrain_path):
             pretrain_param, _ = _get_config_param(pretrain_path)
+            pretrain_param = _clean_param_dtypes(pretrain_param)
 
             pretrain_list = ['use_character_lstm', 'character_embedding_dimension',
                 'character_lstm_hidden_state_dimension', 'token_embedding_dimension',
                 'token_lstm_hidden_state_dimension', 'use_crf']
 
             for name in pretrain_list:
-                if str(param[name]) != str(pretrain_param[name]):
+                if param[name] != pretrain_param[name]:
                     msg = """WARNING: parameter '{0}' was overwritten from '{1}' to '{2}'
                         for consistency with the pretrained model""".format(name,
                             param[name], pretrain_param[name])
@@ -266,12 +268,6 @@ def load_parameters(**kwargs):
         else:
             msg = """Warning: pretraining parameter file not found."""
             print(msg)
-
-    # # if running tests
-    # if param['experiment_name'] == 'test':
-    #     param_file_txt = configparser.ConfigParser()
-    #     test_param_path = os.path.join('test', 'test-parameters-training.ini')
-    #     param_file_txt.read(test_param_path)
 
     # update param_file_txt to reflect the overriding
     param_to_section = utils.get_parameter_to_section_of_configparser(param_file_txt)
@@ -785,7 +781,7 @@ class NeuroNER(object):
             f.write(text)
 
         # Update deploy filepaths
-        dataset_filepaths, dataset_brat_folders = self._get_valid_dataset_filepaths(self.parameters, 
+        dataset_filepaths, dataset_brat_folders = self._get_valid_dataset_filepaths(self.parameters,
             dataset_types=[dataset_type])
         self.dataset_filepaths.update(dataset_filepaths)
         self.dataset_brat_folders.update(dataset_brat_folders)    

--- a/parameters.ini
+++ b/parameters.ini
@@ -66,6 +66,9 @@ number_of_gpus = 0
 [advanced]
 experiment_name = test
 
+# Append the scores to a column in the output file
+output_scores = False
+
 # tagging_format should be either 'bioes' or 'bio'
 tagging_format = bioes
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     # Versions should comply with PEP440. For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.0.4',
+    version='1.0.5',
 
     description='NeuroNER',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     # Versions should comply with PEP440. For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.0.5',
+    version='1.0.6',
 
     description='NeuroNER',
     long_description=long_description,


### PR DESCRIPTION
This pull request:
- Fixes an issue where if param['use_pretrained_model'] was evaluated before the data type had been cleaned. As param['use_pretrained_model'] was a string, both 'True' and 'False' evaluated to True.
- Adds an `output_scores` argument which allows scores to be appended to the output data files (ref #101).