### PR TITLE
avoid error if output_scores not specified

### DIFF
--- a/neuroner/__main__.py
+++ b/neuroner/__main__.py
@@ -16,12 +16,12 @@ warnings.filterwarnings('ignore')
 from neuroner import neuromodel
 
 def parse_arguments(arguments=None):
-    ''' Parse the NeuroNER arguments
+    """
+    Parse the NeuroNER arguments
 
     arguments:
         arguments the arguments, optionally given as argument
-    '''
-    # default_param = neuromodel._get_default_param()
+    """
 
     parser = argparse.ArgumentParser(description='''NeuroNER CLI''', formatter_class=RawTextHelpFormatter)
 

--- a/neuroner/neuromodel.py
+++ b/neuroner/neuromodel.py
@@ -91,7 +91,7 @@ def _fetch(name, content_type=None):
         if os.path.isdir(dest_dir):
             msg = "Directory '{}' already exists.".format(dest_dir)
             print(msg)
-        else: 
+        else:
             shutil.copytree(src_dir, dest_dir)
             msg = "Directory created: '{}'.".format(dest_dir)
             print(msg)
@@ -125,6 +125,7 @@ def _get_default_param():
              'number_of_gpus':0,
              'optimizer':'sgd',
              'output_folder':'./output',
+             'output_scores':False,
              'patience':10,
              'parameters_filepath': os.path.join('.','parameters.ini'),
              'plot_format':'pdf',
@@ -242,7 +243,6 @@ def load_parameters(**kwargs):
 
     # clean the data types
     param = _clean_param_dtypes(param)
-    print(param)
 
     # if loading a pretrained model, set to pretrain hyperparameters
     if param['use_pretrained_model']:
@@ -277,8 +277,7 @@ def load_parameters(**kwargs):
         except:
             pass
 
-    if param['verbose']:
-        pprint(param)
+    pprint(param)
 
     return param, param_file_txt
 
@@ -376,7 +375,7 @@ def check_param_compatibility(parameters, dataset_filepaths):
                 in the specified dataset folder: {0}""".format(parameters['dataset_text_folder'])
             raise IOError(msg)
     # if not parameters['train_model'] and not parameters['use_pretrained_model']:
-    else: 
+    else:
         raise ValueError("At least one of train_model and use_pretrained_model must be set to True.")
 
     if parameters['use_pretrained_model']:
@@ -390,12 +389,16 @@ def check_param_compatibility(parameters, dataset_filepaths):
     if parameters['gradient_clipping_value'] < 0:
         parameters['gradient_clipping_value'] = abs(parameters['gradient_clipping_value'])
 
-    if parameters['output_scores'] and parameters['use_crf']:
-        warn_msg = """Warning when use_crf is True, scores are decoded
-        using the crf. As a result, the scores cannot be directly interpreted
-        in terms of class prediction.
-        """
-        warnings.warn(warn_msg)
+    try:
+        if parameters['output_scores'] and parameters['use_crf']:
+            warn_msg = """Warning when use_crf is True, scores are decoded
+            using the crf. As a result, the scores cannot be directly interpreted
+            in terms of class prediction.
+            """
+            warnings.warn(warn_msg)
+    except KeyError:
+        parameters['output_scores'] = False
+
 
 
 class NeuroNER(object):

--- a/neuroner/train.py
+++ b/neuroner/train.py
@@ -108,10 +108,14 @@ def prediction_step(sess, dataset, dataset_type, model, transition_params_traine
                     break
 
             split_line.append(prediction)
-            if parameters['output_scores']:
-                # space separated scores
-                scores = ' '.join([str(i) for i in scores])
-                split_line.append('{}'.format(scores))
+            try:
+                if parameters['output_scores']:
+                    # space separated scores
+                    scores = ' '.join([str(i) for i in scores])
+                    split_line.append('{}'.format(scores))
+            except KeyError:
+                pass
+
             output_string += ' '.join(split_line) + '\n'
 
         output_file.write(output_string+'\n')

--- a/neuroner/trained_models/conll_2003_en/parameters.ini
+++ b/neuroner/trained_models/conll_2003_en/parameters.ini
@@ -44,4 +44,4 @@ reload_token_embeddings = True
 reload_token_lstm = True
 reload_feedforward = True
 reload_crf = True
-
+output_scores = False

--- a/neuroner/trained_models/i2b2_2014_glove_spacy_bioes/parameters.ini
+++ b/neuroner/trained_models/i2b2_2014_glove_spacy_bioes/parameters.ini
@@ -44,4 +44,4 @@ reload_token_embeddings = True
 reload_token_lstm = True
 reload_feedforward = True
 reload_crf = True
-
+output_scores = False

--- a/neuroner/trained_models/i2b2_2014_glove_stanford_bioes/parameters.ini
+++ b/neuroner/trained_models/i2b2_2014_glove_stanford_bioes/parameters.ini
@@ -44,4 +44,4 @@ reload_token_embeddings = True
 reload_token_lstm = True
 reload_feedforward = True
 reload_crf = True
-
+output_scores = False

--- a/neuroner/trained_models/mimic_glove_spacy_bioes/parameters.ini
+++ b/neuroner/trained_models/mimic_glove_spacy_bioes/parameters.ini
@@ -44,4 +44,4 @@ reload_token_embeddings = True
 reload_token_lstm = True
 reload_feedforward = True
 reload_crf = True
-
+output_scores = False

--- a/neuroner/trained_models/mimic_glove_stanford_bioes/parameters.ini
+++ b/neuroner/trained_models/mimic_glove_stanford_bioes/parameters.ini
@@ -44,4 +44,4 @@ reload_token_embeddings = True
 reload_token_lstm = True
 reload_feedforward = True
 reload_crf = True
-
+output_scores = False

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     # Versions should comply with PEP440. For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.0.6',
+    version='1.0.7',
 
     description='NeuroNER',
     long_description=long_description,


### PR DESCRIPTION
Minor change to prevent the output_scores issue raised in https://github.com/Franck-Dernoncourt/NeuroNER/issues/75.

The only way I've been able to reproduce the error message is to remove `output_scores` from the parameter file, so I updated the pre-trained parameter files and also added a try/except.