### PR TITLE
document correct func call. closes #146

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ neuromodel.fetch_data('example_unannotated_texts')
 neuromodel.fetch_data('i2b2_2014_deid')
 ```
 
-4. Load a pretrained model. The models can be loaded by calling the `neuromodel.fetch_trained_models()` function from a Python interpreter or with the `--fetch_trained_models` argument at the command line.
+4. Load a pretrained model. The models can be loaded by calling the `neuromodel.fetch_model()` function from a Python interpreter or with the `--fetch_trained_models` argument at the command line.
 
 ```
 # Load a pre-trained model from the command line
@@ -90,11 +90,11 @@ neuroner --fetch_trained_model=mimic_glove_stanford_bioes
 ```
 # Load a pre-trained model from a Python interpreter
 from neuroner import neuromodel
-neuromodel.fetch_trained_model('conll_2003_en')
-neuromodel.fetch_trained_model('i2b2_2014_glove_spacy_bioes')
-neuromodel.fetch_trained_model('i2b2_2014_glove_stanford_bioes')
-neuromodel.fetch_trained_model('mimic_glove_spacy_bioes')
-neuromodel.fetch_trained_model('mimic_glove_stanford_bioes')
+neuromodel.fetch_model('conll_2003_en')
+neuromodel.fetch_model('i2b2_2014_glove_spacy_bioes')
+neuromodel.fetch_model('i2b2_2014_glove_stanford_bioes')
+neuromodel.fetch_model('mimic_glove_spacy_bioes')
+neuromodel.fetch_model('mimic_glove_stanford_bioes')
 ```
 
 ### Installing BRAT (optional) 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ pycorenlp==0.3.0
 scikit-learn==0.20.2
 scipy==1.2.0
 spacy==2.0.18
-tensorflow==1.12.0
+tensorflow==1.1.0
 numpy==1.16.0
 # tensorflow-gpu==1.1.0


### PR DESCRIPTION
As noted in #146, the syntax for fetching a model in the interpreter is `neuromodel.fetch_model()`. This pull request updates the readme, plus updates version number for tensorflow in requirements.