### PR TITLE
Fix type for `load_all_pretrained_token_embeddings` arg

### DIFF
--- a/neuroner/neuromodel.py
+++ b/neuroner/neuromodel.py
@@ -201,7 +201,8 @@ def _clean_param_dtypes(param):
             'reload_token_embeddings', 'reload_token_lstm',
             'reload_feedforward', 'reload_crf', 'check_for_lowercase',
             'check_for_digits_replaced_with_zeros', 'output_scores',
-            'freeze_token_embeddings', 'load_only_pretrained_token_embeddings']:
+            'freeze_token_embeddings', 'load_only_pretrained_token_embeddings',
+            'load_all_pretrained_token_embeddings']:
             param[k] = distutils.util.strtobool(v)
 
     return param

--- a/parameters.ini
+++ b/parameters.ini
@@ -38,7 +38,7 @@ character_lstm_hidden_state_dimension = 25
 # token_pretrained_embedding_filepath =
 token_pretrained_embedding_filepath = ./data/word_vectors/glove.6B.100d.txt
 token_embedding_dimension = 100
-token_lstm_hidden_state_dimension = 1
+token_lstm_hidden_state_dimension = 100
 
 use_crf = True
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     # Versions should comply with PEP440. For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.0.7',
+    version='1.0.8',
 
     description='NeuroNER',
     long_description=long_description,


### PR DESCRIPTION
- Fixes an error with the `load_all_pretrained_token_embeddings` argument. False/True were being treated as a string, which lead to a token loading step `if parameters['load_all_pretrained_token_embeddings']` always evaluating to True. 
- sets the default `token_lstm_hidden_state_dimension` to 100 for consistency with the initial release.
- bumps the version.

Running default settings for `neuroner` should now print the following details during setup:

```
Load token embeddings... done (0.19 seconds)
number_of_token_original_case_found: 14618
number_of_token_lowercase_found: 11723
number_of_token_digits_replaced_with_zeros_found: 119
number_of_token_lowercase_and_digits_replaced_with_zeros_found: 16
number_of_loaded_word_vectors: 26476
dataset.vocabulary_size: 28984
```